### PR TITLE
fix: page "emplois", correct link to mentions legale

### DIFF
--- a/docs/fr/emplois/index.html
+++ b/docs/fr/emplois/index.html
@@ -413,7 +413,7 @@
                 <label>
                     <input type="checkbox" id="checkbox_consent" required>
                     J'accepte que ces données soient enregistrées par Sogilis à des fin de recrutement.*
-                    <a href="mentions-legal#gestion-donnees">En savoir plus</a>
+                    <a href="/fr/mentions-legal#gestion-donnees">En savoir plus</a>
                 </label>
             </div>
         </div>


### PR DESCRIPTION
cc @sogilisrc 